### PR TITLE
Fix calculation of imageCount for swapchain create

### DIFF
--- a/VK2D/RendererMeta.c
+++ b/VK2D/RendererMeta.c
@@ -325,6 +325,11 @@ void _vk2dRendererCreateSwapchain() {
 	VK2DRenderer gRenderer = vk2dRendererGetPointer();
 	uint32_t i;
 
+	uint32_t imageCount = gRenderer->surfaceCapabilities.minImageCount + 1;
+	if (gRenderer->surfaceCapabilities.maxImageCount > 0 && imageCount > gRenderer->surfaceCapabilities.maxImageCount) {
+		imageCount = gRenderer->surfaceCapabilities.maxImageCount;
+	}
+
 	gRenderer->config.screenMode = (VK2DScreenMode)_vk2dRendererGetPresentMode((VkPresentModeKHR)gRenderer->config.screenMode);
 	VkSwapchainCreateInfoKHR  swapchainCreateInfoKHR = vk2dInitSwapchainCreateInfoKHR(
 			gRenderer->surface,
@@ -334,7 +339,7 @@ void _vk2dRendererCreateSwapchain() {
 			gRenderer->surfaceHeight,
 			(VkPresentModeKHR)gRenderer->config.screenMode,
 			VK_NULL_HANDLE,
-			gRenderer->surfaceCapabilities.maxImageCount >= 3 ? 3 : gRenderer->surfaceCapabilities.maxImageCount
+			imageCount
 	);
 	VkBool32 supported;
 	vkGetPhysicalDeviceSurfaceSupportKHR(gRenderer->pd->dev, gRenderer->pd->QueueFamily.graphicsFamily, gRenderer->surface, &supported);


### PR DESCRIPTION
Hi! Me and some classmates are using this library for a small game engine we're creating and faced some problems getting VK2D to run on Linux (Ubuntu 22.04). The specific error I got was:
```
Validation Error: [ VUID-VkSwapchainCreateInfoKHR-presentMode-02839 ] | MessageID = 0xfb70ccdb | vkCreateSwapchainKHR(): pCreateInfo->minImageCount 0, which is outside the bounds returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR() (i.e. minImageCount = 3, maxImageCount = 0). The Vulkan spec states: If presentMode is not VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR nor VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR, then minImageCount must be greater than or equal to the value returned in the minImageCount member of the VkSurfaceCapabilitiesKHR structure returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR for the surface (https://vulkan.lunarg.com/doc/view/1.3.268.0/linux/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-presentMode-02839)
```

Essentially, the values I had on my system were `minImageCount = 3` and `maxImageCount = 0`, which wasn't correctly handled before. This PR fixes this by always allowing `minImageCount +1 ` images in the swapchain and if `maxImageCount` is above 0 and below `minImageCount`, we use `maxImageCount` instead.

The new calculation is based on the code provided on [vulkan-tutorial.com](https://vulkan-tutorial.com/Drawing_a_triangle/Presentation/Swap_chain).