### PR TITLE
Fix potential race condition, add convenience functions for logging

### DIFF
--- a/VK2D/Logger.c
+++ b/VK2D/Logger.c
@@ -140,10 +140,11 @@ writeTimeString(char *buf)
 	SDL_DateTime dt;
 
 	if (!SDL_GetCurrentTime(&time)
-	    && !SDL_TimeToDateTime(time, &dt, true)) {
+	    || !SDL_TimeToDateTime(time, &dt, true)) {
 		memset(buf, '-', MAX_TIME_STRING_SIZE);
 		return;
 	}
+
 	snprintf(buf, MAX_TIME_STRING_SIZE, "%s %s %i %02d:%02d:%02d %i",
 	    WEEK_DAYS[dt.day_of_week], MONTHS[dt.month - 1], dt.day, dt.hour,
 	    dt.minute, dt.second, dt.year);
@@ -277,3 +278,23 @@ vk2dDefaultLoggerSetSeverity(const VK2DLogSeverity severity)
 	gDefaultLogger.severity = severity;
 	SDL_UnlockMutex(gDefaultLogger.mutex);
 }
+
+#define LOG_WRAP_FN(NAME, SEVERITY)                                            \
+	void vk2dLog##NAME##v(const char *fmt, va_list ap)                     \
+	{                                                                      \
+		vk2dLoggerLogv(VK2D_LOG_SEVERITY_##SEVERITY, fmt, ap);         \
+	}                                                                      \
+                                                                               \
+	void vk2dLog##NAME(const char *fmt, ...)                               \
+	{                                                                      \
+		va_list ap;                                                    \
+		va_start(ap, fmt);                                             \
+		vk2dLoggerLogv(VK2D_LOG_SEVERITY_##SEVERITY, fmt, ap);         \
+		va_end(ap);                                                    \
+	}
+
+LOG_WRAP_FN(Debug, DEBUG)
+LOG_WRAP_FN(Info, INFO)
+LOG_WRAP_FN(Warn, WARN)
+LOG_WRAP_FN(Error, ERROR)
+LOG_WRAP_FN(Fatal, FATAL)

--- a/VK2D/Logger.c
+++ b/VK2D/Logger.c
@@ -179,7 +179,7 @@ defaultLog(void *ptr, VK2DLogSeverity severity, const char *msg)
 	writeTimeString(timeString);
 	// asctime() adds an extra \n at the end
 	timeString[MAX_TIME_STRING_SIZE - 2] = '\0';
-	fprintf(out, "[%s]%s[%s] %s\n", timeString, padding, label, msg);
+	fprintf(out, "[%s] [%s]%s %s\n", timeString, label, padding, msg);
 	fflush(out);
 	if (severity == VK2D_LOG_SEVERITY_FATAL) abort();
 }

--- a/VK2D/Logger.h
+++ b/VK2D/Logger.h
@@ -32,3 +32,40 @@ void vk2dDefaultLoggerSetErrorOutput(FILE *out);
 
 /// \brief Sets the minimum severity level for logging in the default logger.
 void vk2dDefaultLoggerSetSeverity(VK2DLogSeverity severity);
+
+/// \brief Prints a printf() style message with VK2D_LOG_SEVERITY_DEBUG severity
+void vk2dLogDebug(const char *fmt, ...);
+
+/// \brief Prints a vprintf() style message with VK2D_LOG_SEVERITY_DEBUG
+///        severity
+void vk2dLogDebugv(const char *fmt, va_list ap);
+
+/// \brief Prints a printf() style message with VK2D_LOG_SEVERITY_INFO severity
+void vk2dLogInfo(const char* fmt, ...);
+
+/// \brief Prints a vprintf() style message with VK2D_LOG_SEVERITY_INFO severity
+void vk2dLogInfov(const char* fmt, va_list ap);
+
+/// \brief Prints a printf() style message with VK2D_LOG_SEVERITY_WARN severity
+void vk2dLogWarn(const char* fmt, ...);
+
+/// \brief Prints a vprintf() style message with VK2D_LOG_SEVERITY_WARN severity
+void vk2dLogWarnv(const char* fmt, va_list ap);
+
+/// \brief Prints a printf() style message with VK2D_LOG_SEVERITY_ERROR severity
+void vk2dLogError(const char* fmt, ...);
+
+/// \brief Prints a vprintf() style message with VK2D_LOG_SEVERITY_ERROR severity
+void vk2dLogErrorv(const char* fmt, va_list ap);
+
+/// \brief Prints a printf() style message with VK2D_LOG_SEVERITY_FATAL severity
+void vk2dLogFatal(const char* fmt, ...);
+
+/// \brief Prints a vprintf() style message with VK2D_LOG_SEVERITY_FATAL severity
+void vk2dLogFatalv(const char* fmt, va_list ap);
+
+/// \brief Prints a printf() style message with VK2D_LOG_SEVERITY_UNKNOWN
+void vk2dLogUnknown(const char* fmt, ...);
+
+/// \brief Prints a vprintf() style message with VK2D_LOG_SEVERITY_UNKNOWN
+void vk2dLogUnknownv(const char* fmt, va_list ap);

--- a/VK2D/LogicalDevice.c
+++ b/VK2D/LogicalDevice.c
@@ -7,12 +7,13 @@
 #include "VK2D/Opaque.h"
 #include "VK2D/Util.h"
 #include "VK2D/Renderer.h"
+#include "VK2D/Logger.h"
 #include <malloc.h>
 
 VK2DLogicalDevice gDeviceFromMainThread;
 
 VK2DLogicalDevice vk2dLogicalDeviceCreate(VK2DPhysicalDevice dev, bool enableAllFeatures, bool graphicsDevice, bool debug, VK2DRendererLimits *limits) {
-    vk2dLog("Creating queues...");
+    vk2dLogInfo("Creating queues...");
 	VK2DRenderer gRenderer = vk2dRendererGetPointer();
 	VK2DLogicalDevice ldev = malloc(sizeof(struct VK2DLogicalDevice_t));
 	uint32_t queueFamily = graphicsDevice == true ? dev->QueueFamily.graphicsFamily : dev->QueueFamily.computeFamily;
@@ -114,7 +115,7 @@ VK2DLogicalDevice vk2dLogicalDeviceCreate(VK2DPhysicalDevice dev, bool enableAll
         }
 
 		if (gRenderer->limits.supportsMultiThreadLoading) {
-            vk2dLog("Creating worker thread...");
+            vk2dLogInfo("Creating worker thread...");
 			ldev->loadList = NULL;
 			ldev->loadListMutex = SDL_CreateMutex();
 			ldev->shaderMutex = SDL_CreateMutex();

--- a/VK2D/PhysicalDevice.c
+++ b/VK2D/PhysicalDevice.c
@@ -6,6 +6,7 @@
 #include "VK2D/Constants.h"
 #include "VK2D/Opaque.h"
 #include "VK2D/Renderer.h"
+#include "VK2D/Logger.h"
 #include <stdio.h>
 #include <malloc.h>
 
@@ -135,7 +136,7 @@ VK2DPhysicalDevice vk2dPhysicalDeviceFind(VkInstance instance, int32_t preferred
 
 		// Check if we found one and print if it was discrete (dedicated) or otherwise
 		if (choice != VK_NULL_HANDLE) {
-            vk2dLog(foundPrimary ? "Found discrete device %s [Vulkan %i.%i.%i]"
+            vk2dLogInfo(foundPrimary ? "Found discrete device %s [Vulkan %i.%i.%i]"
                                  : "Found integrated device %s [Vulkan %i.%i.%i]",
                     choiceProps.deviceName, VK_VERSION_MAJOR(choiceProps.apiVersion),
                     VK_VERSION_MINOR(choiceProps.apiVersion), VK_VERSION_PATCH(choiceProps.apiVersion));

--- a/VK2D/Renderer.c
+++ b/VK2D/Renderer.c
@@ -21,6 +21,7 @@
 #include "VK2D/DescriptorControl.h"
 #include "VK2D/Opaque.h"
 #include "VK2D/Pipeline.h"
+#include "VK2D/Logger.h"
 
 /******************************* Forward declarations *******************************/
 
@@ -138,16 +139,16 @@ VK2DResult vk2dRendererInit(SDL_Window *window, VK2DRendererConfig config, VK2DS
         }
 
 		// Log all used extensions
-        vk2dLog("Vulkan Enabled Instance Extensions: ");
+        vk2dLogInfo("Vulkan Enabled Instance Extensions: ");
 		for (i = 0; i < extensionCount; i++)
-            vk2dLog(" - %s", extensions[i]);
-        vk2dLog(""); // Newline
+            vk2dLogInfo(" - %s", extensions[i]);
+        vk2dLogInfo(""); // Newline
 
         // List all used layers
-        vk2dLog("Vulkan Enabled Instance Layers: ");
+        vk2dLogInfo("Vulkan Enabled Instance Layers: ");
         for (i = 0; i < layerCount; i++)
-            vk2dLog("  - %s", layers[i]);
-        vk2dLog("");
+            vk2dLogInfo("  - %s", layers[i]);
+        vk2dLogInfo("");
         free(systemLayers);
 
 		// Create instance, physical, and logical device
@@ -300,7 +301,7 @@ void vk2dRendererQuit() {
 		vk2dPhysicalDeviceFree(gRenderer->pd);
 		free(gRenderer->vmaBudgets);
 
-        vk2dLog("VK2D has been uninitialized.");
+        vk2dLogInfo("VK2D has been uninitialized.");
 		vk2dValidationEnd();
 		free(gRenderer);
 		gRenderer = NULL;
@@ -576,7 +577,7 @@ void vk2dRendererSetTarget(VK2DTexture target) {
 
 			// Dont let the user bind textures that are not targets
 			if (target != VK2D_TARGET_SCREEN && !vk2dTextureIsTarget(target)) {
-                vk2dLog("Texture cannot be used as a target.");
+                vk2dLogInfo("Texture cannot be used as a target.");
 				return;
 			}
 

--- a/VK2D/RendererMeta.c
+++ b/VK2D/RendererMeta.c
@@ -405,7 +405,7 @@ void _vk2dRendererCreateSwapchain() {
                             break;
                         }
                     }
-                    vk2dLog("Swapchain (%i images) initialized...", swapchainCreateInfoKHR.minImageCount);
+                    vk2dLogInfo("Swapchain (%i images) initialized...", swapchainCreateInfoKHR.minImageCount);
                 } else {
                     vk2dRaise(VK2D_STATUS_VULKAN_ERROR, "Failed to acquire swapchain images, Vulkan error %i.", result);
                 }
@@ -455,7 +455,7 @@ void _vk2dRendererCreateDepthBuffer() {
 	if (selectedFormat != VK_FORMAT_MAX_ENUM) {
 		gRenderer->depthBufferFormat = selectedFormat;
 		gRenderer->depthBuffer = vk2dImageCreate(gRenderer->ld, gRenderer->surfaceWidth, gRenderer->surfaceHeight, gRenderer->depthBufferFormat, VK_IMAGE_ASPECT_DEPTH_BIT, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, (VkSampleCountFlagBits)gRenderer->config.msaa);
-        vk2dLog("Depth buffer initialized...");
+        vk2dLogInfo("Depth buffer initialized...");
 	} else {
         vk2dRaise(VK2D_STATUS_VULKAN_ERROR, "Failed to acquire depth format.");
 	}
@@ -481,9 +481,9 @@ void _vk2dRendererCreateColourResources() {
 				VK_IMAGE_ASPECT_COLOR_BIT,
 				VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
 				(VkSampleCountFlagBits) gRenderer->config.msaa);
-        vk2dLog("MSAA %ix enabled...", gRenderer->config.msaa);
+        vk2dLogInfo("MSAA %ix enabled...", gRenderer->config.msaa);
 	} else {
-        vk2dLog("MSAA disabled...");
+        vk2dLogInfo("MSAA disabled...");
 	}
 }
 
@@ -514,7 +514,7 @@ void _vk2dRendererCreateDescriptorBuffers() {
 	gRenderer->limits.maxInstancedDraws = maxDrawCommands < maxDrawInstances ? maxDrawCommands : maxDrawInstances;
 	gRenderer->limits.maxInstancedDraws--;
 
-    vk2dLog("Descriptor buffers created...");
+    vk2dLogInfo("Descriptor buffers created...");
 }
 
 void _vk2dRendererDestroyDescriptorBuffers() {
@@ -664,7 +664,7 @@ void _vk2dRendererCreateRenderPass() {
         return;
     }
 
-    vk2dLog("Render pass initialized...");
+    vk2dLogInfo("Render pass initialized...");
 }
 
 void _vk2dRendererDestroyRenderPass() {
@@ -769,7 +769,7 @@ void _vk2dRendererCreateDescriptorSetLayouts() {
 	    return;
 	}
 
-    vk2dLog("Descriptor set layout initialized...");
+    vk2dLogInfo("Descriptor set layout initialized...");
 }
 
 void _vk2dRendererDestroyDescriptorSetLayout() {
@@ -938,7 +938,7 @@ void _vk2dRendererCreatePipelines() {
 
     // In case something somewhere failed
     if (!vk2dStatusFatal())
-        vk2dLog("Pipelines initialized...");
+        vk2dLogInfo("Pipelines initialized...");
 }
 
 void _vk2dRendererDestroyPipelines(bool preserveCustomPipes) {
@@ -979,7 +979,7 @@ void _vk2dRendererCreateFrameBuffer() {
 			VkFramebufferCreateInfo framebufferCreateInfo = vk2dInitFramebufferCreateInfo(gRenderer->renderPass, gRenderer->surfaceWidth, gRenderer->surfaceHeight, attachments, attachCount);
 			VkResult result = vkCreateFramebuffer(gRenderer->ld->dev, &framebufferCreateInfo, VK_NULL_HANDLE, &gRenderer->framebuffers[i]);
 			if (result == VK_SUCCESS) {
-                vk2dLog("Framebuffer[%i] ready...", i);
+                vk2dLogInfo("Framebuffer[%i] ready...", i);
             } else {
                 if (result == VK_ERROR_OUT_OF_HOST_MEMORY) {
                     vk2dRaise(VK2D_STATUS_OUT_OF_RAM, "Failed to create framebuffer, out of memory.");
@@ -991,7 +991,7 @@ void _vk2dRendererCreateFrameBuffer() {
                 break;
 			}
 		}
-        vk2dLog("Framebuffers initialized...");
+        vk2dLogInfo("Framebuffers initialized...");
 	} else {
 	    vk2dRaise(VK2D_STATUS_OUT_OF_RAM, "Failed to allocate framebuffer list.");
 	}
@@ -1048,7 +1048,7 @@ void _vk2dRendererCreateUniformBuffers(bool newCamera) {
 	gRenderer->cameras[VK2D_DEFAULT_CAMERA].spec.h = gRenderer->surfaceHeight;
 
 	if (!vk2dStatusFatal())
-        vk2dLog("UBO initialized...");
+        vk2dLogInfo("UBO initialized...");
 }
 
 void _vk2dRendererDestroyUniformBuffers() {
@@ -1101,7 +1101,7 @@ void _vk2dRendererCreateDescriptorPool(bool preserveDescCons) {
             if (result != VK_SUCCESS || result2 != VK_SUCCESS)
                 vk2dRaise(VK2D_STATUS_VULKAN_ERROR, "Failed to allocate descriptor set, Vulkan error %i/%i.", result, result2);
             else
-                vk2dLog("Descriptor controllers initialized...");
+                vk2dLogInfo("Descriptor controllers initialized...");
 		} else {
 		    vk2dRaise(VK2D_STATUS_VULKAN_ERROR, "Failed to allocate descriptor pool, Vulkan error %i.", result);
 		}
@@ -1151,7 +1151,7 @@ void _vk2dRendererCreateDescriptorPool(bool preserveDescCons) {
         for (int i = 0; i < VK2D_MAX_FRAMES_IN_FLIGHT; i++)
             gRenderer->uboDescriptorSets[i] = vk2dDescConGetSet(gRenderer->descConVP);
 	} else {
-        vk2dLog("Descriptor controllers preserved...");
+        vk2dLogInfo("Descriptor controllers preserved...");
 	}
 }
 
@@ -1212,7 +1212,7 @@ void _vk2dRendererCreateSynchronization() {
 	}
 
 	if (!vk2dStatusFatal())
-        vk2dLog("Synchronization initialized...");
+        vk2dLogInfo("Synchronization initialized...");
 }
 
 void _vk2dRendererDestroySynchronization() {
@@ -1259,7 +1259,7 @@ void _vk2dRendererCreateSampler() {
 	vkUpdateDescriptorSets(gRenderer->ld->dev, 1, &write, 0, VK_NULL_HANDLE);
 
 	if (r1 == VK_SUCCESS && r2 == VK_SUCCESS)
-        vk2dLog("Created texture sampler...");
+        vk2dLogInfo("Created texture sampler...");
 	else
 	    vk2dRaise(VK2D_STATUS_VULKAN_ERROR, "Failed to create sampler descriptor sets, Vulkan error %i/%i.", r1, r2);
 }
@@ -1289,7 +1289,7 @@ void _vk2dRendererCreateUnits() {
 	gRenderer->unitCircleOutline = vk2dPolygonCreateOutline(circleVertices, VK2D_CIRCLE_VERTICES);
 	gRenderer->unitLine = vk2dPolygonCreateOutline((void*)LINE_VERTICES, LINE_VERTEX_COUNT);
     if (!vk2dStatusFatal())
-        vk2dLog("Created unit polygons...");
+        vk2dLogInfo("Created unit polygons...");
 }
 
 void _vk2dRendererDestroyUnits() {
@@ -1350,7 +1350,7 @@ void _vk2dRendererRefreshTargets() {
 		}
 	}
 	if (!vk2dStatusFatal())
-        vk2dLog("Refreshed %i render targets...", targetsRefreshed);
+        vk2dLogInfo("Refreshed %i render targets...", targetsRefreshed);
 }
 
 void _vk2dRendererDestroyTargetsList() {
@@ -1395,7 +1395,7 @@ void _vk2dRendererResetSwapchain() {
 	_vk2dRendererDestroyColourResources();
 	_vk2dRendererDestroySwapchain();
 
-    vk2dLog("Destroyed swapchain assets...");
+    vk2dLogInfo("Destroyed swapchain assets...");
 
 	// Swap out configs in case they were changed
 	gRenderer->config = gRenderer->newConfig;
@@ -1415,7 +1415,7 @@ void _vk2dRendererResetSwapchain() {
 	_vk2dRendererCreateSynchronization();
 
 	if (!vk2dStatusFatal())
-        vk2dLog("Recreated swapchain assets...");
+        vk2dLogInfo("Recreated swapchain assets...");
 }
 
 

--- a/VK2D/ShadowEnvironment.c
+++ b/VK2D/ShadowEnvironment.c
@@ -6,6 +6,7 @@
 #include "VK2D/Opaque.h"
 #include "VK2D/Constants.h"
 #include "VK2D/Renderer.h"
+#include "VK2D/Logger.h"
 
 // From Math.h
 void identityMatrix(float m[]);
@@ -26,7 +27,7 @@ VK2DShadowEnvironment vk2DShadowEnvironmentCreate() {
         se->objectInfos = NULL;
         vk2dShadowEnvironmentAddObject(se);
     } else {
-        vk2dLog("Failed to create shadow environment.");
+        vk2dLogInfo("Failed to create shadow environment.");
     }
 
     return se;
@@ -62,7 +63,7 @@ VK2DShadowObject vk2dShadowEnvironmentAddObject(VK2DShadowEnvironment shadowEnvi
         memset(soi->model, 0, sizeof(mat4));
         identityMatrix(soi->model);
     } else {
-        vk2dLog("Failed to create shadow object.");
+        vk2dLogInfo("Failed to create shadow object.");
     }
 
     return so;
@@ -117,7 +118,7 @@ void vk2DShadowEnvironmentAddEdge(VK2DShadowEnvironment shadowEnvironment, float
             shadowEnvironment->verticesSize += VK2D_DEFAULT_ARRAY_EXTENSION * 6;
         } else {
             failedToExtendList = true;
-            vk2dLog("Failed to extend shadow list");
+            vk2dLogInfo("Failed to extend shadow list");
         }
     }
 

--- a/VK2D/Structs.h
+++ b/VK2D/Structs.h
@@ -152,12 +152,22 @@ typedef enum {
 } VK2DAssetState;
 
 typedef enum {
-	VK2D_LOG_SEVERITY_DEBUG = 0,   ///< Debug message
-	VK2D_LOG_SEVERITY_INFO = 1,    ///< Standard log message
-	VK2D_LOG_SEVERITY_WARN = 2,    ///< Warning
-	VK2D_LOG_SEVERITY_ERROR = 3,   ///< Error
-	VK2D_LOG_SEVERITY_FATAL = 4,   ///< Unrecoverable error. The logger will abort after printing
-	VK2D_LOG_SEVERITY_UNKNOWN = 5, ///< Unknown severity, will be printed on all
+	/// \brief Debug message
+	VK2D_LOG_SEVERITY_DEBUG = 0,
+	/// \brief Standard log message
+	VK2D_LOG_SEVERITY_INFO = 1,
+	/// \brief Warning
+	VK2D_LOG_SEVERITY_WARN = 2,
+	/// \brief Error, recoverable
+	VK2D_LOG_SEVERITY_ERROR = 3,
+	/// \brief Fatal error, system is in an invalid, unrecoverable state
+	/// \note The supplied logger is expected to abort here, abort() will
+	///       be called if the supplied logger does not abort.
+	VK2D_LOG_SEVERITY_FATAL = 4,
+	/// \brief Unknown severity level.
+	/// \note This will get printed on all error outputs, regardless of
+	///       severity.
+	VK2D_LOG_SEVERITY_UNKNOWN = 5,
 } VK2DLogSeverity;
 
 // VK2D pointers
@@ -406,9 +416,10 @@ typedef void (*VK2DLoggerDestroyFn)(void *context);
 typedef VK2DLogSeverity (*VK2DLoggerSeverityFn)(void *context);
 
 /// \brief Contains logging callbacks and context
+/// \note
 struct VK2DLogger {
 	/// \brief Callback to log the message.
-	/// \note Must not be NULL! This will kill the program.
+	/// \note MUST NOT BE NULL! This will kill the program.
 	VK2DLoggerLogFn log;
 	/// \brief Callback called on destruction of logger.
 	/// \note May be NULL, in which case no destructor is called.

--- a/VK2D/Structs.h
+++ b/VK2D/Structs.h
@@ -388,15 +388,38 @@ struct VK2DAssetLoad {
 	} Output; ///< How the user will receive the loaded asset
 };
 
-typedef void (*VK2DLoggerLogFn)(void *, VK2DLogSeverity, const char *);
-typedef void (*VK2DLoggerDestroyFn)(void *);
-typedef VK2DLogSeverity (*VK2DLoggerSeverityFn)(void *);
 
+/// \brief Callback function for logging
+/// \param context User supplied context
+/// \param severity Severity of the log message. If value supplied is not within
+///                 the range of the enum, it will be coerced to
+///                 VK2D_LOG_SEVERITY_UNKNOWN
+/// \param message Message to log
+typedef void (*VK2DLoggerLogFn)(void *context, VK2DLogSeverity severity, const char *message);
+
+/// \brief Callback function for destroying the logger
+/// \param context User supplied context
+typedef void (*VK2DLoggerDestroyFn)(void *context);
+
+/// \brief Retrieves the log severity from the user context.
+/// \param context User supplied context.
+typedef VK2DLogSeverity (*VK2DLoggerSeverityFn)(void *context);
+
+/// \brief Contains logging callbacks and context
 struct VK2DLogger {
-	VK2DLoggerLogFn log;             ///< Callback to log the message
-	VK2DLoggerDestroyFn destroy;     ///< Callback called on destruction of logger
-	VK2DLoggerSeverityFn severityFn; ///< Callback to get minimum severity of logger
-	void *context;                   ///< User supplied context
+	/// \brief Callback to log the message.
+	/// \note Must not be NULL! This will kill the program.
+	VK2DLoggerLogFn log;
+	/// \brief Callback called on destruction of logger.
+	/// \note May be NULL, in which case no destructor is called.
+	VK2DLoggerDestroyFn destroy;
+	/// \brief Callback to get minimum severity of logger.
+	/// \note May be NULL, in which case all messages will be logged,
+	///       regardless of severity.
+	VK2DLoggerSeverityFn severityFn;
+	/// \brief User supplied context, passed to log() when called.
+	/// \note May be NULL, this is a convenience pointer for the user.
+	void *context;
 };
 
 VK2D_USER_STRUCT(VK2DVertexColour)

--- a/VK2D/Texture.c
+++ b/VK2D/Texture.c
@@ -1,18 +1,20 @@
 /// \file Texture.c
 /// \author Paolo Mazzon
+#include <malloc.h>
 #include "VK2D/Texture.h"
+#include "VK2D/Buffer.h"
+#include "VK2D/DescriptorControl.h"
 #include "VK2D/Image.h"
 #include "VK2D/Initializers.h"
 #include "VK2D/LogicalDevice.h"
-#include "VK2D/Validation.h"
+#include "VK2D/Opaque.h"
 #include "VK2D/Polygon.h"
 #include "VK2D/Renderer.h"
-#include "VK2D/Buffer.h"
-#include "VK2D/DescriptorControl.h"
-#include "VK2D/stb_image.h"
-#include "VK2D/Opaque.h"
 #include "VK2D/Util.h"
-#include <malloc.h>
+#include "VK2D/Validation.h"
+#include "VK2D/stb_image.h"
+
+#include "Logger.h"
 
 static void _vk2dTextureAddToTextureArray(VK2DTexture tex) {
     VK2DRenderer gRenderer = vk2dRendererGetPointer();
@@ -101,7 +103,7 @@ VK2DTexture _vk2dTextureFromInternal(void *data, int size, bool mainThread) {
 VK2DTexture vk2dTextureFrom(void *data, int size) {
 	VK2DTexture tex = _vk2dTextureFromInternal(data, size, true);
 	if (tex == NULL)
-        vk2dLog("Failed to load texture from data of size %i.", size);
+        vk2dLogInfo("Failed to load texture from data of size %i.", size);
 	else
         _vk2dTextureAddToTextureArray(tex);
 	return tex;
@@ -115,6 +117,8 @@ VK2DTexture vk2dTextureLoad(const char *filename) {
         tex = _vk2dTextureFromInternal(data, size, true);
         _vk2dTextureAddToTextureArray(tex);
         free(data);
+    } else {
+
     }
 	return tex;
 }

--- a/VK2D/Util.c
+++ b/VK2D/Util.c
@@ -13,6 +13,7 @@
 #include "VK2D/Texture.h"
 #include "VK2D/Shader.h"
 #include "VK2D/Model.h"
+#include "VK2D/Logger.h"
 
 static float gLoadStatus = 0;
 
@@ -202,23 +203,23 @@ int _vk2dWorkerThread(void *data) {
 				uint8_t *fileData = _vk2dLoadFile(asset.Load.filename, &size);
 				*asset.Output.texture = _vk2dTextureFromInternal(fileData, size, false);
 				if (*asset.Output.texture == NULL)
-                    vk2dLog("Failed to load texture \"%s\".", asset.Load.filename);
+                    vk2dLogInfo("Failed to load texture \"%s\".", asset.Load.filename);
 				free(fileData);
 			} else if (asset.type == VK2D_ASSET_TYPE_TEXTURE_MEMORY) {
 				*asset.Output.texture = _vk2dTextureFromInternal(asset.Load.data, asset.Load.size, false);
 				if (*asset.Output.texture == NULL)
-                    vk2dLog("Failed to load texture from buffer.");
+                    vk2dLogInfo("Failed to load texture from buffer.");
 			} else if (asset.type == VK2D_ASSET_TYPE_MODEL_FILE) {
 				uint32_t size;
 				uint8_t *fileData = _vk2dLoadFile(asset.Load.filename, &size);
 				*asset.Output.model = _vk2dModelFromInternal(fileData, size, *asset.Data.Model.tex, false);
 				if (*asset.Output.model == NULL)
-                    vk2dLog("Failed to load model \"%s\".", asset.Load.filename);
+                    vk2dLogInfo("Failed to load model \"%s\".", asset.Load.filename);
 				free(fileData);
 			} else if (asset.type == VK2D_ASSET_TYPE_MODEL_MEMORY) {
 				*asset.Output.model = _vk2dModelFromInternal(asset.Load.data, asset.Load.size, *asset.Data.Model.tex, false);
 				if (*asset.Output.model == NULL)
-                    vk2dLog("Failed to load model from buffer.");
+                    vk2dLogInfo("Failed to load model from buffer.");
 			} else if (asset.type == VK2D_ASSET_TYPE_SHADER_FILE) {
 				// Shaders are internally synchronized
 				*asset.Output.shader = vk2dShaderLoad(asset.Load.filename, asset.Load.fragmentFilename, asset.Data.Shader.uniformBufferSize);
@@ -277,23 +278,23 @@ void vk2dAssetsLoad(VK2DAssetLoad *assets, uint32_t count) {
 				uint8_t *fileData = _vk2dLoadFile(asset.Load.filename, &size);
 				*asset.Output.texture = _vk2dTextureFromInternal(fileData, size, true);
 				if (*asset.Output.texture == NULL)
-                    vk2dLog("Failed to load texture \"%s\".", asset.Load.filename);
+                    vk2dLogInfo("Failed to load texture \"%s\".", asset.Load.filename);
 				free(fileData);
 			} else if (asset.type == VK2D_ASSET_TYPE_TEXTURE_MEMORY) {
 				*asset.Output.texture = _vk2dTextureFromInternal(asset.Load.data, asset.Load.size, true);
 				if (*asset.Output.texture == NULL)
-                    vk2dLog("Failed to load texture from buffer.");
+                    vk2dLogInfo("Failed to load texture from buffer.");
 			} else if (asset.type == VK2D_ASSET_TYPE_MODEL_FILE) {
 				uint32_t size;
 				uint8_t *fileData = _vk2dLoadFile(asset.Load.filename, &size);
 				*asset.Output.model = _vk2dModelFromInternal(fileData, size, *asset.Data.Model.tex, true);
 				if (*asset.Output.model == NULL)
-                    vk2dLog("Failed to load model \"%s\".", asset.Load.filename);
+                    vk2dLogInfo("Failed to load model \"%s\".", asset.Load.filename);
 				free(fileData);
 			} else if (asset.type == VK2D_ASSET_TYPE_MODEL_MEMORY) {
 				*asset.Output.model = _vk2dModelFromInternal(asset.Load.data, asset.Load.size, *asset.Data.Model.tex, true);
 				if (*asset.Output.model == NULL)
-                    vk2dLog("Failed to load model from buffer.");
+                    vk2dLogInfo("Failed to load model from buffer.");
 			} else if (asset.type == VK2D_ASSET_TYPE_SHADER_FILE) {
 				// Shaders are internally synchronized
 				*asset.Output.shader = vk2dShaderLoad(asset.Load.filename, asset.Load.fragmentFilename, asset.Data.Shader.uniformBufferSize);

--- a/VK2D/Validation.c
+++ b/VK2D/Validation.c
@@ -91,13 +91,6 @@ const char *vk2dStatusMessage() {
 	return gLogBuffer;
 }
 
-void vk2dLog(const char* fmt, ...) {
-	va_list ap;
-	va_start(ap, fmt);
-	vk2dLoggerLogv(VK2D_LOG_SEVERITY_INFO, fmt, ap);
-	va_end(ap);
-}
-
 VKAPI_ATTR VkBool32 VKAPI_CALL _vk2dDebugCallback(VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT objectType, uint64_t sourceObject, size_t location, int32_t messageCode, const char* layerPrefix, const char* message, void* data) {
 	VK2DRenderer gRenderer = vk2dRendererGetPointer();
 	char firstHalf[1000];

--- a/VK2D/Validation.h
+++ b/VK2D/Validation.h
@@ -10,9 +10,6 @@
 extern "C" {
 #endif
 
-/// \brief Prints a log message if VKRE_VERBOSE_STDOUT is enabled
-void vk2dLog(const char* fmt, ...);
-
 /// \brief Raises a status problem of some sort
 void vk2dRaise(VK2DStatus result, const char* fmt, ...);
 


### PR DESCRIPTION
Realized when I went to look at your touch-up on the time string function there was a race condition in destroyLogger(). Also, moved the SDL_*Time calls into an if statement since doing it in an assert would probably cause weird issues if assertions were disabled. Won't fail if it can't read the time now either, probably not good if it dies in logging. Added some helper functions that call the underlying logger too, and moved vk2dLog() into one of those (specifically defaulting to logging at the INFO severity level).
Will stop spamming pull requests soon hopefully sorry.