### PR TITLE
Don't blow the stack when the renderer init fails

### DIFF
--- a/VK2D/Logger.c
+++ b/VK2D/Logger.c
@@ -148,7 +148,6 @@ static void destroyLogger(const bool lock) {
 }
 
 static void defaultLog(void *ptr, VK2DLogSeverity severity, const char *msg) {
-    VK2DRenderer gRenderer = vk2dRendererGetPointer();
     const VK2DDefaultLogger *log = (VK2DDefaultLogger *)ptr;
     assert(usingDefaultLogger());
     COERCE_SEVERITY(severity);
@@ -163,7 +162,7 @@ static void defaultLog(void *ptr, VK2DLogSeverity severity, const char *msg) {
     writeTimeString(timeString);
     // asctime() adds an extra \n at the end
     timeString[MAX_TIME_STRING_SIZE - 2] = '\0';
-    if (gRenderer->options.stdoutLogging) {
+    if (vk2dRendererHasStdoutLogging()) {
         fprintf(out, "[%s] [%s]%s %s\n", timeString, label, padding, msg);
         fflush(out);
     }

--- a/VK2D/Renderer.c
+++ b/VK2D/Renderer.c
@@ -341,6 +341,10 @@ VK2DRendererConfig vk2dRendererGetConfig() {
 	return c;
 }
 
+bool vk2dRendererHasStdoutLogging() {
+	return gRenderer == NULL || gRenderer->options.stdoutLogging;
+}
+
 void vk2dRendererSetConfig(VK2DRendererConfig config) {
 	if (vk2dRendererGetPointer() != NULL) {
 		gRenderer->newConfig = config;

--- a/VK2D/Renderer.h
+++ b/VK2D/Renderer.h
@@ -118,6 +118,14 @@ VK2DRenderer vk2dRendererGetPointer();
 /// up to 8x msaa, this function will return a configuration with 8x msaa.
 VK2DRendererConfig vk2dRendererGetConfig();
 
+/// \brief Checks if the renderer is set to log to stdout.
+/// \return true if stdout is enabled in the config or the renderer is NULL.
+///
+/// This is necessary because if the renderer is NULL when something tries to
+/// access it and the default log function is used, it will recurse until it
+/// blows the stack.
+bool vk2dRendererHasStdoutLogging();
+
 /// \brief Resets the renderer with a new configuration
 /// \param config New render user configuration to use
 ///

--- a/examples/main/main.c
+++ b/examples/main/main.c
@@ -1,6 +1,7 @@
 #define SDL_MAIN_HANDLED
 #include <SDL3/SDL_vulkan.h>
 #include <stdbool.h>
+#include <stdlib.h>
 #include "VK2D/VK2D.h"
 #include "VK2D/Validation.h"
 #include <stdio.h>


### PR DESCRIPTION
`defaultLog()` calls `vk2dRendererGetPointer()` by default to check if its supposed to log to stdout. This is a problem, since `vk2dRaise()` is called by `vk2dRendererGetPointer()` if the renderer is NULL. `vk2dRaise()` in turn calls `vk2dLoggerLogv()`, which when the user has not supplied a custom logger will call `defaultLog()`, and we have a turtles all the way down scenario. 

To fix that, add a `vk2dRendererHasStdoutLogging()` function that checks if the renderer is NULL first, and call that instead in `defaultLog()`.